### PR TITLE
Cent os 8 stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,0 @@
-# CentOS Cloud SIG image repository.
-
-Master repository is for scripts or appropriate documentation. Images are
-branched per major version.
-
-Images are generated from kickstart scripts in the [sig-cloud-instance-build](https://github.com/CentOS/sig-cloud-instance-build/) repository.

--- a/docker/CentOS
+++ b/docker/CentOS
@@ -1,1 +1,0 @@
-populate this file with docker commit info

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM registry.access.redhat.com/ubi8:latest
+
+LABEL maintainer="The CentOS Project"
+
+LABEL com.redhat.component="centos-stream-container" \
+      name="centos-stream" \
+      version="8"
+
+LABEL com.redhat.license_terms="https://centos.org/legal/licensing-policy/"
+
+LABEL summary="Provides a CentOS Stream container based on the Red Hat Universal Base Image"
+LABEL description="CentOS Stream is a continuously delivered distro that tracks just ahead of Red Hat Enterprise Linux development. This image takes the Red Hat UBI and layers on content from CentOS Stream"
+LABEL io.k8s.display-name="CentOS Stream 8"
+LABEL io.openshift.expose-services=""
+LABEL io.openshift.tags="base centos centos-stream"
+
+
+RUN rpm -ivh --replacefiles http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-release-8.4-1.el8.noarch.rpm \
+                            http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \
+                            http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm \
+    && rpm -e redhat-release \
+    && dnf --setopt=tsflags=nodocs --setopt=install_weak_deps=false -y distro-sync \
+    && dnf remove -y subscription-manager dnf-plugin-subscription-manager\
+    && dnf clean all \
+    && rm -f /etc/yum.repos.d/ubi.repo

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,10 +14,8 @@ LABEL io.k8s.display-name="CentOS Stream 8"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="base centos centos-stream"
 
-
-RUN rpm -ivh --replacefiles http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-release-8.4-1.el8.noarch.rpm \
-                            http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-8-2.el8.noarch.rpm \
-                            http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-2.el8.noarch.rpm \
+RUN dnf download --repofrompath=centos,http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/ --disablerepo=* --enablerepo=centos centos-stream-release centos-stream-repos centos-gpg-keys
+RUN rpm -ivh --nodeps --replacefiles *.rpm && rm *.rpm \
     && rpm -e redhat-release \
     && dnf --setopt=tsflags=nodocs --setopt=install_weak_deps=false -y distro-sync \
     && dnf remove -y subscription-manager dnf-plugin-subscription-manager\


### PR DESCRIPTION
### Description

The changes in this pull request involve updating the content related to CentOS Stream container in the Dockerfile and removing unnecessary content from the repository.

- Removed `README.md` and `docker/CentOS`.
- Added `docker/Dockerfile` for CentOS Stream container.
- Updated Dockerfile to pull from `registry.access.redhat.com/ubi8:latest` as the base image for CentOS Stream container.
- Added relevant labels for maintainer, component, license terms, summary, description, display name, expose services, and tags.
- Included commands to download CentOS Stream related packages, install them, remove unnecessary packages, clean up, and remove UBI repository configuration.

These changes aim to improve the clarity and accuracy of the CentOS Stream container setup within the project.